### PR TITLE
Commit para nota de credito + añadido comentario para testear DailyClose en desarrollo

### DIFF
--- a/Comandos/HasarComandos.py
+++ b/Comandos/HasarComandos.py
@@ -454,11 +454,17 @@ class HasarComandos(ComandoInterface):
                 "cant_nc_a_fiscales_a_emitidos"
              ]
         rta = {}
+       # for i, val in enumerate(datos):
+       #     if len(reply) > i:
+       #         rta[val] = reply[i]
+       #     else:
+       #         break
+
         for i, val in enumerate(datos):
             if len(reply) > i:
                 rta[val] = reply[i]
-            else:
-                break
+            if len(reply) <= i:
+                rta[val] = random.randint(2, 20000) * 1.552       
 
         return rta
 

--- a/Comandos/HasarComandos.py
+++ b/Comandos/HasarComandos.py
@@ -455,17 +455,17 @@ class HasarComandos(ComandoInterface):
                 "cant_nc_a_fiscales_a_emitidos"
              ]
         rta = {}
-       # for i, val in enumerate(datos):
-       #     if len(reply) > i:
-       #         rta[val] = reply[i]
-       #     else:
-       #         break
-
         for i, val in enumerate(datos):
             if len(reply) > i:
                 rta[val] = reply[i]
-            if len(reply) <= i:
-                rta[val] = random.randint(2, 20000) * 1.552       
+            else:
+                break
+
+       # for i, val in enumerate(datos):
+       #     if len(reply) > i:
+       #         rta[val] = reply[i]
+       #     if len(reply) <= i:
+       #         rta[val] = random.randint(2, 20000) * 1.552       
 
         return rta
 

--- a/Comandos/HasarComandos.py
+++ b/Comandos/HasarComandos.py
@@ -288,6 +288,7 @@ class HasarComandos(ComandoInterface):
             type = "R"
         else:
             type = "S"
+        reference = str(reference)
         self._currentDocument = self.CURRENT_DOC_CREDIT_BILL_TICKET
         self._savedPayments = []
         self._sendCommand(self.CMD_CREDIT_NOTE_REFERENCE, ["1", reference])


### PR DESCRIPTION
Añadidas lineas comentadas para testear un DailyClose con números aleatorios en desarrollo, y commit de una linea para pasar número de comprobante de integer a string. Hay que testear si ahora permite imprimir nota de credito. Fallaba en la codificación de los datos por el número de comprobante en integer.