### PR TITLE
Nuevos campos de item para descuentos / recargos por item

### DIFF
--- a/Comandos/HasarComandos.py
+++ b/Comandos/HasarComandos.py
@@ -349,10 +349,10 @@ class HasarComandos(ComandoInterface):
             return status
         raise NotImplementedError
 
-    def addItem(self, description, quantity, price, iva, discount=0, discountDescription='', negative=False):
+    def addItem(self, description, quantity, price, iva, itemNegative=False, discount=0, discountDescription='', discountNegative=True):
         if type(description) in types.StringTypes:
             description = [description]
-        if negative:
+        if itemNegative:
             sign = 'm'
         else:
             sign = 'M'
@@ -366,10 +366,14 @@ class HasarComandos(ComandoInterface):
                                    [self._formatText(description[-1], 'lineItem'),
                                      quantityStr, priceUnitStr, ivaStr, sign, "0.0", "1", "T"])
         if discount:
+            if discountNegative:
+                sign = 'm'
+            else:
+                sign = 'M'
             discountStr = str(float(discount)).replace(",", ".")
             self._sendCommand(self.CMD_LAST_ITEM_DISCOUNT,
                 [self._formatText(discountDescription, 'discountDescription'), discountStr,
-                  "m", "1", "T"])
+                  sign, "1", "T"])
         return reply
 
     def addPayment(self, description, payment):

--- a/Comandos/HasarComandos.py
+++ b/Comandos/HasarComandos.py
@@ -98,20 +98,8 @@ class HasarComandos(ComandoInterface):
                   'generalDiscount': 50,
                   'embarkItem': 108,
                  'receiptText': 106,
-                },
-        "615": {
-                'nonFiscalText': 40,
-                'customerName': 30,
-                'custAddressSize': 40,
-                'paymentDescription': 30,
-                'fiscalText': 20,
-                'lineItem': 20,
-                'lastItemDiscount': 20,
-                'generalDiscount': 20,
-                'embarkItem': 108,
-                'receiptText': 106,
                 }
-        }
+    }
 
 
     docTypeNames = {
@@ -241,10 +229,11 @@ class HasarComandos(ComandoInterface):
                        doc or " ",
                        ivaType,   # Iva Comprador
                        docType or " ", # Tipo de Doc.
-                       address or " ",
                        ]
         if self.model in ["715v1", "715v2", "320"]:
             parameters.append(self._formatText(address, 'custAddressSize') or " ") # Domicilio
+        else:
+            parameters.append(address or " ")
         return self._sendCommand(self.CMD_SET_CUSTOMER_DATA, parameters)
 
     def openBillTicket(self, type, name, address, doc, docType, ivaType):

--- a/Traductores/TraductorFiscal.py
+++ b/Traductores/TraductorFiscal.py
@@ -122,15 +122,15 @@ class TraductorFiscal(TraductorInterface):
 	 
 		return ret
 
-	def _imprimirItem(self, ds, qty, importe, alic_iva=21.):
+	def _imprimirItem(self, ds, qty, importe, alic_iva=21., itemNegative=False, discount=0, discountDescription='', discountNegative=True):
 		"Envia un item (descripcion, cantidad, etc.) a una factura"
 		self.factura["items"].append(dict(ds=ds, qty=qty, 
-										  importe=importe, alic_iva=alic_iva))
+										  importe=importe, alic_iva=alic_iva, itemNegative=itemNegative,
+										  discount=discount, discountDescription=discountDescription, discountNegative=discountNegative))
 		##ds = unicode(ds, "latin1") # convierto a latin1
 		# Nota: no se calcula neto, iva, etc (deben venir calculados!)
-		discount = discountDescription =  None
 		return self.comando.addItem(ds, float(qty), float(importe), float(alic_iva), 
-									discount, discountDescription)
+									itemNegative, float(discount), discountDescription, discountNegative)
 
 	def _imprimirPago(self, ds, importe):
 		"Imprime una linea con la forma de pago y monto"

--- a/Traductores/TraductorFiscal.py
+++ b/Traductores/TraductorFiscal.py
@@ -129,6 +129,9 @@ class TraductorFiscal(TraductorInterface):
 										  discount=discount, discountDescription=discountDescription, discountNegative=discountNegative))
 		##ds = unicode(ds, "latin1") # convierto a latin1
 		# Nota: no se calcula neto, iva, etc (deben venir calculados!)
+		if discountDescription == '':
+			discountDescription = ds
+			print("DS: ", discountDescription)
 		return self.comando.addItem(ds, float(qty), float(importe), float(alic_iva), 
 									itemNegative, float(discount), discountDescription, discountNegative)
 

--- a/Traductores/TraductoresHandler.py
+++ b/Traductores/TraductoresHandler.py
@@ -279,7 +279,7 @@ class TraductoresHandler:
 
 	def _getAvaliablePrinters(self):	
 		#Esta función llama a otra que busca impresoras. Luego se encarga de escribir el config.ini con las impresoras encontradas.
-		self.__getPrintersAndWriteConfig()
+		#self.__getPrintersAndWriteConfig()
 
 		# la primer seccion corresponde a SERVER, el resto son las impresoras
 		rta = {


### PR DESCRIPTION
For issue #16 
Añadidos nuevos campos para pasar opcionalmente por item, el cual tendría la siguiente lista de campos:
alic_iva = iva del producto **OBLIGATORIO**
importe = importe del producto **OBLIGATORIO**
ds = descripcion del producto **OBLIGATORIO**
qty = cantidad del producto **OBLIGATORIO**
**NUEVO** itemNegative = booleano (true or false) por defecto false. Si esta en true, el importe del producto sera negativo (ideal para poder descontar un producto entero) **OPCIONAL**
**NUEVO** discount = importe del descuento del item actual **OPCIONAL**
**NUEVO** discountDescription = descripción del descuento **OPCIONAL**
**NUEVO** discountNegativo = booleano (true or false) por defecto true. Si esta en true, esto sera un descuento. Si es false, el discount sera un recargo. **OPCIONAL**

EJs: 
item sin recargos o descuentos:
```JSON
{
"alic_iva": 21.0,
"importe": 0.12,
"ds": "COCA",
"qty": 2.0
}
```

item negativo (se imprime el item con el importe en negativo, por lo tanto, es una resta):
```JSON
{
"alic_iva": 21.0,
"importe": 0.12,
"ds": "COCA",
"qty": 2.0,
"itemNegative": true
}
```

item con descuento:
```JSON
{
"alic_iva": 21.0,
"importe": 12,
"ds": "COCA",
"qty": 2.0,
"discount":10.5,
"discountDescription":"Descuento de promoción: día de la zaraza",
}
```
item con recargo:
```JSON
{
"alic_iva": 21.0,
"importe": 12,
"ds": "COCA",
"qty": 2.0,
"discount":10.5,
"discountDescription":"Recargo por plato roto",
"discountNegative": false
}
```

Otro cambio:
En el segundo commit, comento la llamada a mi función que a su vez llama a la de @wDirac  otra vez, ya que sigue tirando error de kerError: 'vendor'.

cambios 21/07/2017:

- Removido indice de textSizeDict duplicado.
- Commit para issue #19 
- campo discountDescription ya no es obligatorio, si no va seteado o vacio, toma el valor del campo ds.