### PR TITLE
Hasar2gen

### DIFF
--- a/Comandos/ComandoFiscalInterface.py
+++ b/Comandos/ComandoFiscalInterface.py
@@ -60,6 +60,11 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
         """Cierra el documento que esté abierto"""
         raise NotImplementedError
 
+
+    def setTrailer(self, trailer=None):
+        """Establecer pie"""
+        raise NotImplementedError
+
     def cancelDocument(self):
         """Cancela el documento que esté abierto"""
         raise NotImplementedError

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -114,7 +114,7 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 
 	def cancelDocument(self):
 		"""Cancela el documento que esté abierto"""
-		jdata = {"Cancelar" : { }}
+		jdata = {"Cancelar" : {}}
 		self.conector.sendCommand( jdata )
 
 	def addItem(self, description, quantity, price, iva, discount, discountDescription, negative=False, *kargs):

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -7,236 +7,328 @@ from Comandos.ComandoFiscalInterface import ComandoFiscalInterface
 from Drivers.FiscalPrinterDriver import PrinterException
 from ComandoInterface import formatText
 
-NUMBER = 999990
 
 
 class Hasar2GenComandos(ComandoFiscalInterface):
-    # el traductor puede ser: TraductorFiscal o TraductorReceipt
-    # path al modulo de traductor que este comando necesita
-    traductorModule = "Traductores.TraductorFiscal"
+	# el traductor puede ser: TraductorFiscal o TraductorReceipt
+	# path al modulo de traductor que este comando necesita
+	traductorModule = "Traductores.TraductorFiscal"
 
-    DEFAULT_DRIVER = "Json"
+	DEFAULT_DRIVER = "Json"
 
-    
-    AVAILABLE_MODELS = ["PT-1000F","PT-250F", "P-HAS-5100-FAR"]
-
-
-    docTypeNames = {
-        "DOC_TYPE_CUIT": "CUIT",
-        "DOC_TYPE_LIBRETA_ENROLAMIENTO": 'L.E.',
-        "DOC_TYPE_LIBRETA_CIVICA": 'L.C.',
-        "DOC_TYPE_DNI": 'DNI',
-        "DOC_TYPE_PASAPORTE": 'PASAP',
-        "DOC_TYPE_CEDULA": 'CED',
-        "DOC_TYPE_SIN_CALIFICADOR": 'S/C'
-    }
-
-    docTypes = {
-        "CUIT": 'C',
-        "LIBRETA_ENROLAMIENTO": '0',
-        "LIBRETA_CIVICA": '1',
-        "DNI": '2',
-        "PASAPORTE": '3',
-        "CEDULA": '4',
-        "SIN_CALIFICADOR": ' ',
-    }
-
-    ivaTypes = {
-        "RESPONSABLE_INSCRIPTO": 'I',
-        "RESPONSABLE_NO_INSCRIPTO": 'N',
-        "EXENTO": 'E',
-        "NO_RESPONSABLE": 'A',
-        "CONSUMIDOR_FINAL": 'C',
-        "RESPONSABLE_NO_INSCRIPTO_BIENES_DE_USO": 'B',
-        "RESPONSABLE_MONOTRIBUTO": 'M',
-        "MONOTRIBUTISTA_SOCIAL": 'S',
-        "PEQUENIO_CONTRIBUYENTE_EVENTUAL": 'V',
-        "PEQUENIO_CONTRIBUYENTE_EVENTUAL_SOCIAL": 'W',
-        "NO_CATEGORIZADO": 'T',
-    }
+	
+	AVAILABLE_MODELS = ["PT-1000F","PT-250F", "P-HAS-5100-FAR"]
 
 
-    def printTicket(self, **kargs): 
-    	pass
+	docTypeNames = {
+		"DOC_TYPE_CUIT": "CUIT",
+		"DOC_TYPE_LIBRETA_ENROLAMIENTO": 'L.E.',
+		"DOC_TYPE_LIBRETA_CIVICA": 'L.C.',
+		"DOC_TYPE_DNI": 'DNI',
+		"DOC_TYPE_PASAPORTE": 'PASAP',
+		"DOC_TYPE_CEDULA": 'CED',
+		"DOC_TYPE_SIN_CALIFICADOR": 'S/C'
+	}
+
+	docTypes = {
+		"CUIT": 'C',
+		"LIBRETA_ENROLAMIENTO": '0',
+		"LIBRETA_CIVICA": '1',
+		"DNI": '2',
+		"PASAPORTE": '3',
+		"CEDULA": '4',
+		"SIN_CALIFICADOR": ' ',
+	}
+
+	ivaTypes = {
+		"RESPONSABLE_INSCRIPTO": 'I',
+		"RESPONSABLE_NO_INSCRIPTO": 'N',
+		"EXENTO": 'E',
+		"NO_RESPONSABLE": 'A',
+		"CONSUMIDOR_FINAL": 'C',
+		"RESPONSABLE_NO_INSCRIPTO_BIENES_DE_USO": 'B',
+		"RESPONSABLE_MONOTRIBUTO": 'M',
+		"MONOTRIBUTISTA_SOCIAL": 'S',
+		"PEQUENIO_CONTRIBUYENTE_EVENTUAL": 'V',
+		"PEQUENIO_CONTRIBUYENTE_EVENTUAL_SOCIAL": 'W',
+		"NO_CATEGORIZADO": 'T',
+	}
+
 
 
 	def _sendCommand(self, commandNumber, parameters, skipStatusErrors=False):
 		pass
 
-    # Documentos no fiscales
 
-    def openNonFiscalReceipt(self):
-        """Abre documento no fiscal"""
-        pass
+	def _setCustomerData(self, name=" ", address=" ", doc=" ", docType=" ", ivaType="T"):
 
-    def printNonFiscalText(self, text):
-        """Imprime texto fiscal. Si supera el límite de la linea se trunca."""
-        pass
-
-    NON_FISCAL_TEXT_MAX_LENGTH = 40  # Redefinir
-
-    def closeDocument(self):
-        """Cierra el documento que esté abierto"""
-        pass
-
-    def cancelDocument(self):
-        """Cancela el documento que esté abierto"""
-        pass
-
-    def addItem(self, description, quantity, price, iva, discount, discountDescription, negative=False):
-        """Agrega un item a la FC.
-            @param description          Descripción del item. Puede ser un string o una lista.
-                Si es una lista cada valor va en una línea.
-            @param quantity             Cantidad
-            @param price                Precio (incluye el iva si la FC es B o C, si es A no lo incluye)
-            @param iva                  Porcentaje de iva
-            @param negative             True->Resta de la FC
-            @param discount             Importe de descuento
-            @param discountDescription  Descripción del descuento
-        """
-        pass
-
-    def addPayment(self, description, payment):
-        """Agrega un pago a la FC.
-            @param description  Descripción
-            @param payment      Importe
-        """
-        pass
-
-    docTypeNames = {
-        "DOC_TYPE_CUIT": "CUIT",
-        "DOC_TYPE_LIBRETA_ENROLAMIENTO": 'L.E.',
-        "DOC_TYPE_LIBRETA_CIVICA": 'L.C.',
-        "DOC_TYPE_DNI": 'DNI',
-        "DOC_TYPE_PASAPORTE": 'PASAP',
-        "DOC_TYPE_CEDULA": 'CED',
-        "DOC_TYPE_SIN_CALIFICADOR": 'S/C'
-    }
-
-    # Ticket fiscal (siempre es a consumidor final, no permite datos del cliente)
-
-    def openTicket(self):
-        """Abre documento fiscal"""
-        pass
-
-    def openBillTicket(self, type, name, address, doc, docType, ivaType):
-        """
-        Abre un ticket-factura
-            @param  type        Tipo de Factura "A", "B", o "C"
-            @param  name        Nombre del cliente
-            @param  address     Domicilio
-            @param  doc         Documento del cliente según docType
-            @param  docType     Tipo de documento
-            @param  ivaType     Tipo de IVA
-        """
-        pass
-
-    def openBillCreditTicket(self, type, name, address, doc, docType, ivaType, reference="NC"):
-        """
-        Abre un ticket-NC
-            @param  type        Tipo de Factura "A", "B", o "C"
-            @param  name        Nombre del cliente
-            @param  address     Domicilio
-            @param  doc         Documento del cliente según docType
-            @param  docType     Tipo de documento
-            @param  ivaType     Tipo de IVA
-            @param  reference
-        """
-        pass
-
-    def openDebitNoteTicket(self, type, name, address, doc, docType, ivaType):
-        """
-        Abre una Nota de Débito
-            @param  type        Tipo de Factura "A", "B", o "C"
-            @param  name        Nombre del cliente
-            @param  address     Domicilio
-            @param  doc         Documento del cliente según docType
-            @param  docType     Tipo de documento
-            @param  ivaType     Tipo de IVA
-            @param  reference
-        """
-        pass
-
-    def openRemit(self, name, address, doc, docType, ivaType):
-        """
-        Abre un remito
-            @param  name        Nombre del cliente
-            @param  address     Domicilio
-            @param  doc         Documento del cliente según docType
-            @param  docType     Tipo de documento
-            @param  ivaType     Tipo de IVA
-        """
-        pass
-
-    def openReceipt(self, name, address, doc, docType, ivaType, number):
-        """
-        Abre un recibo
-            @param  name        Nombre del cliente
-            @param  address     Domicilio
-            @param  doc         Documento del cliente según docType
-            @param  docType     Tipo de documento
-            @param  ivaType     Tipo de IVA
-            @param  number      Número de identificación del recibo (arbitrario)
-        """
-        pass
-
-    def addRemitItem(self, description, quantity):
-        """Agrega un item al remito
-            @param description  Descripción
-            @param quantity     Cantidad
-        """
-        pass
-
-    def addReceiptDetail(self, descriptions, amount):
-        """Agrega el detalle del recibo
-            @param descriptions Lista de descripciones (lineas)
-            @param amount       Importe total del recibo
-        """
-        pass
-
-    def addAdditional(self, description, amount, iva, negative=False):
-        """Agrega un adicional a la FC.
-            @param description  Descripción
-            @param amount       Importe (sin iva en FC A, sino con IVA)
-            @param iva          Porcentaje de Iva
-            @param negative True->Descuento, False->Recargo"""
-        pass
-
-    def getLastNumber(self, letter):
-        """Obtiene el último número de FC"""
-        pass
-
-    def getLastCreditNoteNumber(self, letter):
-        """Obtiene el último número de FC"""
-        pass
-
-    def getLastRemitNumber(self):
-        """Obtiene el último número de Remtio"""
-        pass
-
-    def cancelAnyDocument(self):
-        """Cancela cualquier documento abierto, sea del tipo que sea.
-           No requiere que previamente se haya abierto el documento por este objeto.
-           Se usa para destrabar la impresora."""
-        pass
-
-    def dailyClose(self, type):
-        """Cierre Z (diario) o X (parcial)
-            @param type     Z (diario), X (parcial)
-        """
-        pass
-
-    def getWarnings(self):
-        return []
-
-    def openDrawer(self):
-        """Abrir cajón del dinero - No es mandatory implementarlo"""
-        print("vino comando aca")
-    	jdata = {
-			"AbrirDocumento":
+		jdata = {
+			"CargarDatosCliente":
 			{
+			"RazonSocial" : name,
+			"NumeroDocumento" : doc,
+			"ResponsabilidadIVA" : "ResponsableInscripto",
+			"TipoDocumento" : "TipoCUIT",
+			"Domicilio" : address
+			}
+			}
+
+		self.conector.sendCommand( jdata )
+
+	# Documentos no fiscales
+
+	def openNonFiscalReceipt(self):
+		"""Abre documento no fiscal"""
+		pass
+
+	def printFiscalText(self, text):
+		jdata = {"ImprimirTextoFiscal":{
+			"Atributos" : [ "Centrado" ],
+			"Texto" : "Producto en oferta: Sólo por hoy !",
+			"ModoDisplay" : "DisplayNo"
+		}}
+
+		self.conector.sendCommand( jdata )
+
+	def printNonFiscalText(self, text):
+		"""Imprime texto fiscal. Si supera el límite de la linea se trunca."""
+		pass
+		{"ImprimirTextoGenerico":{
+			"Atributos" : [ "Negrita" ],
+			"Texto" : text,
+			"ModoDisplay" : "DisplayNo"
+		}}
+
+		self.conector.sendCommand( jdata )
+
+	def closeDocument(self, copias = 0, email = None):
+		"""Cierra el documento que esté abierto"""
+		jdata = {"CerrarDocumento": {
+			"Copias" : str(copias),		
+		}}
+
+		jdata["CerrarDocumento"]["DireccionEMail"] = email
+
+		self.conector.sendCommand( jdata )
+
+
+	def cancelDocument(self):
+		"""Cancela el documento que esté abierto"""
+		jdata = {"Cancelar" : { }}
+		self.conector.sendCommand( jdata )
+
+	def addItem(self, description, quantity, price, iva, discount, discountDescription, negative=False, *kargs):
+		"""Agrega un item a la FC.
+			@param description          Descripción del item. Puede ser un string o una lista.
+				Si es una lista cada valor va en una línea.
+			@param quantity             Cantidad
+			@param price                Precio (incluye el iva si la FC es B o C, si es A no lo incluye)
+			@param iva                  Porcentaje de iva
+			@param negative             True->Resta de la FC
+			@param discount             Importe de descuento
+			@param discountDescription  Descripción del descuento
+		"""
+		jdata = {"ImprimirItem": {
+					"Descripcion" : description,
+					"Cantidad" : quantity,
+					"PrecioUnitario" : price,
+					"CondicionIVA" : "Gravado",
+					"AlicuotaIVA" : iva,
+					"OperacionMonto" : "ModoSumaMonto",
+					"TipoImpuestoInterno" : "IIVariableKIVA",
+					"MagnitudImpuestoInterno" : "0.00",
+					"ModoDisplay" : "DisplayNo",
+					"ModoBaseTotal" : "ModoPrecioTotal",
+					}
+				}
+		self.conector.sendCommand( jdata )
+
+		if discount and not negative:
+			jdata= {"ImprimirDescuentoItem": {
+				"Descripcion" : discountDescription,
+				"Monto" : discount,
+				"ModoDisplay" : "DisplayNo",
+				"ModoBaseTotal" : "ModoPrecioTotal"
+				}}
+			self.conector.sendCommand( jdata )
+
+		if discount and negative:
+			jdata = {"ImprimirAjuste":{
+				"Descripcion" : discountDescription,
+				"Monto" : discount,
+				"ModoDisplay" : "DisplayNo",
+				"Operacion" : "AjusteNeg"
+			}}
+
+			self.conector.sendCommand( jdata )
+
+	def addPayment(self, description, payment):
+		"""Agrega un pago a la FC.
+			@param description  Descripción
+			@param payment      Importe
+		"""
+		jdata = {"ImprimirPago":	{
+		"Descripcion" : description,
+		"Monto" : payment,
+		"Operacion" : "Pagar",
+		"ModoDisplay" : "DisplayNo",
+		}}
+
+		self.conector.sendCommand( jdata )
+
+	
+
+	# Ticket fiscal (siempre es a consumidor final, no permite datos del cliente)
+
+	def openTicket(self):
+		"""Abre documento fiscal"""
+		jdata = {"AbrirDocumento":{
 			"CodigoComprobante" : "TiqueFacturaB"
 			}
 		}
-    
-    	self.conector.sendCommand( jdata, 1,1 )
+	
+		self.conector.sendCommand( jdata )
+
+	def openBillTicket(self, type, name, address, doc, docType, ivaType):
+		"""
+		Abre un ticket-factura
+			@param  type        Tipo de Factura "A", "B", o "C"
+			@param  name        Nombre del cliente
+			@param  address     Domicilio
+			@param  doc         Documento del cliente según docType
+			@param  docType     Tipo de documento
+			@param  ivaType     Tipo de IVA
+		"""
+		if name and doc:
+			_setCustomerData(name, address, doc, docType, ivaType)
+
+		jdata = {"AbrirDocumento":{
+			"CodigoComprobante" : "TiqueFacturaB"
+			}
+		}
+	
+		self.conector.sendCommand( jdata )
+
+	def openBillCreditTicket(self, type, name, address, doc, docType, ivaType, reference="NC"):
+		"""
+		Abre un ticket-NC
+			@param  type        Tipo de Factura "A", "B", o "C"
+			@param  name        Nombre del cliente
+			@param  address     Domicilio
+			@param  doc         Documento del cliente según docType
+			@param  docType     Tipo de documento
+			@param  ivaType     Tipo de IVA
+			@param  reference
+		"""
+		pass
+
+	def openDebitNoteTicket(self, type, name, address, doc, docType, ivaType):
+		"""
+		Abre una Nota de Débito
+			@param  type        Tipo de Factura "A", "B", o "C"
+			@param  name        Nombre del cliente
+			@param  address     Domicilio
+			@param  doc         Documento del cliente según docType
+			@param  docType     Tipo de documento
+			@param  ivaType     Tipo de IVA
+			@param  reference
+		"""
+		pass
+
+	def openRemit(self, name, address, doc, docType, ivaType):
+		"""
+		Abre un remito
+			@param  name        Nombre del cliente
+			@param  address     Domicilio
+			@param  doc         Documento del cliente según docType
+			@param  docType     Tipo de documento
+			@param  ivaType     Tipo de IVA
+		"""
+		pass
+
+	def openReceipt(self, name, address, doc, docType, ivaType, number):
+		"""
+		Abre un recibo
+			@param  name        Nombre del cliente
+			@param  address     Domicilio
+			@param  doc         Documento del cliente según docType
+			@param  docType     Tipo de documento
+			@param  ivaType     Tipo de IVA
+			@param  number      Número de identificación del recibo (arbitrario)
+		"""
+		pass
+
+	def addRemitItem(self, description, quantity):
+		"""Agrega un item al remito
+			@param description  Descripción
+			@param quantity     Cantidad
+		"""
+		pass
+
+	def addReceiptDetail(self, descriptions, amount):
+		"""Agrega el detalle del recibo
+			@param descriptions Lista de descripciones (lineas)
+			@param amount       Importe total del recibo
+		"""
+		pass
+
+	def addAdditional(self, description, amount, iva, negative=False):
+		"""Agrega un adicional a la FC.
+			@param description  Descripción
+			@param amount       Importe (sin iva en FC A, sino con IVA)
+			@param iva          Porcentaje de Iva
+			@param negative True->Descuento, False->Recargo"""
+		pass
+
+		
+
+	def setCodigoBarras(self, numero , tipoCodigo = "CodigoTipoI2OF5", imprimeNumero =  "ImprimeNumerosCodigo" ):
+		jdata = {"CargarCodigoBarras":
+			{
+			"TipoCodigo" : tipoCodigo,
+			"Numero" : numero,
+			"ImprimeNumero" : imprimeNumero,
+			"Almacena" : "ProgramaCodigo"
+			}
+		}
+
+	def getLastNumber(self, letter):
+		"""Obtiene el último número de FC"""
+		pass
+
+	def getLastCreditNoteNumber(self, letter):
+		"""Obtiene el último número de FC"""
+		pass
+
+	def getLastRemitNumber(self):
+		"""Obtiene el último número de Remtio"""
+		pass
+
+	def cancelAnyDocument(self):
+		"""Cancela cualquier documento abierto, sea del tipo que sea.
+		   No requiere que previamente se haya abierto el documento por este objeto.
+		   Se usa para destrabar la impresora."""
+		pass
+
+	def dailyClose(self, type):
+		"""Cierre Z (diario) o X (parcial)
+			@param type     Z (diario), X (parcial)
+		"""
+		if type.upper() == "Z":
+			reporteTal = "ReporteZ"
+		else:
+			reporteTal = "ReporteX"
+		jdata = {"CerrarJornadaFiscal":{
+			"Reporte" : reporteTal
+		}}
+
+		self.conector.sendCommand( jdata )
+
+	def getWarnings(self):
+		return []
+
+	def openDrawer(self):
+		"""Abrir cajón del dinero - No es mandatory implementarlo"""
+		jdata = {"AbrirCajonDinero" : {}}
+
+		self.conector.sendCommand( jdata )

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -1,13 +1,30 @@
-# -*- coding: iso-8859-1 -*-
-import ComandoInterface
+# -*- coding: utf-8 -*-
 import logging
 
+NUMBER = 999990
 
-class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
-    """Interfaz que deben cumplir las impresoras fiscales."""
 
+class Hasar2GenComandos:
+    # el traductor puede ser: TraductorFiscal o TraductorReceipt
+    # path al modulo de traductor que este comando necesita
+    traductorModule = "Traductores.TraductorFiscal"
+
+    DEFAULT_DRIVER = "ReceiptDirectJet"
 
     
+    AVAILABLE_MODELS = ["PT-1000F","PT-250F", "P-HAS-5100-FAR"]
+
+
+    docTypeNames = {
+        "DOC_TYPE_CUIT": "CUIT",
+        "DOC_TYPE_LIBRETA_ENROLAMIENTO": 'L.E.',
+        "DOC_TYPE_LIBRETA_CIVICA": 'L.C.',
+        "DOC_TYPE_DNI": 'DNI',
+        "DOC_TYPE_PASAPORTE": 'PASAP',
+        "DOC_TYPE_CEDULA": 'CED',
+        "DOC_TYPE_SIN_CALIFICADOR": 'S/C'
+    }
+
     docTypes = {
         "CUIT": 'C',
         "LIBRETA_ENROLAMIENTO": '0',
@@ -33,36 +50,34 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
     }
 
 
-    def _sendCommand(self, commandNumber, parameters, skipStatusErrors=False):
-        print "_sendCommand", commandNumber, parameters
-        try:
-            logging.getLogger().info("sendCommand: SEND|0x%x|%s|%s" % (commandNumber,
-                                                                       skipStatusErrors and "T" or "F",
-                                                                       str(parameters)))
-            return self.conector.sendCommand(commandNumber, parameters, skipStatusErrors)
-        except epsonFiscalDriver.ComandoException, e:
-            logging.getLogger().error("epsonFiscalDriver.ComandoException: %s" % str(e))
-            raise ComandoException("Error de la impresora fiscal: " + str(e))
+    def printTicket(self, **kargs): 
+    	pass
+
+    
+
+
+	def _sendCommand(self, commandNumber, parameters, skipStatusErrors=False):
+		pass
 
     # Documentos no fiscales
 
     def openNonFiscalReceipt(self):
         """Abre documento no fiscal"""
-        raise NotImplementedError
+        pass
 
     def printNonFiscalText(self, text):
         """Imprime texto fiscal. Si supera el límite de la linea se trunca."""
-        raise NotImplementedError
+        pass
 
     NON_FISCAL_TEXT_MAX_LENGTH = 40  # Redefinir
 
     def closeDocument(self):
         """Cierra el documento que esté abierto"""
-        raise NotImplementedError
+        pass
 
     def cancelDocument(self):
         """Cancela el documento que esté abierto"""
-        raise NotImplementedError
+        pass
 
     def addItem(self, description, quantity, price, iva, discount, discountDescription, negative=False):
         """Agrega un item a la FC.
@@ -75,14 +90,14 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
             @param discount             Importe de descuento
             @param discountDescription  Descripción del descuento
         """
-        raise NotImplementedError
+        pass
 
     def addPayment(self, description, payment):
         """Agrega un pago a la FC.
             @param description  Descripción
             @param payment      Importe
         """
-        raise NotImplementedError
+        pass
 
     docTypeNames = {
         "DOC_TYPE_CUIT": "CUIT",
@@ -98,7 +113,7 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
 
     def openTicket(self):
         """Abre documento fiscal"""
-        raise NotImplementedError
+        pass
 
     def openBillTicket(self, type, name, address, doc, docType, ivaType):
         """
@@ -110,7 +125,7 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
             @param  docType     Tipo de documento
             @param  ivaType     Tipo de IVA
         """
-        raise NotImplementedError
+        pass
 
     def openBillCreditTicket(self, type, name, address, doc, docType, ivaType, reference="NC"):
         """
@@ -123,7 +138,7 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
             @param  ivaType     Tipo de IVA
             @param  reference
         """
-        raise NotImplementedError
+        pass
 
     def openDebitNoteTicket(self, type, name, address, doc, docType, ivaType):
         """
@@ -136,7 +151,7 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
             @param  ivaType     Tipo de IVA
             @param  reference
         """
-        raise NotImplementedError
+        pass
 
     def openRemit(self, name, address, doc, docType, ivaType):
         """
@@ -147,7 +162,7 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
             @param  docType     Tipo de documento
             @param  ivaType     Tipo de IVA
         """
-        raise NotImplementedError
+        pass
 
     def openReceipt(self, name, address, doc, docType, ivaType, number):
         """
@@ -159,21 +174,21 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
             @param  ivaType     Tipo de IVA
             @param  number      Número de identificación del recibo (arbitrario)
         """
-        raise NotImplementedError
+        pass
 
     def addRemitItem(self, description, quantity):
         """Agrega un item al remito
             @param description  Descripción
             @param quantity     Cantidad
         """
-        raise NotImplementedError
+        pass
 
     def addReceiptDetail(self, descriptions, amount):
         """Agrega el detalle del recibo
             @param descriptions Lista de descripciones (lineas)
             @param amount       Importe total del recibo
         """
-        raise NotImplementedError
+        pass
 
     def addAdditional(self, description, amount, iva, negative=False):
         """Agrega un adicional a la FC.
@@ -181,35 +196,43 @@ class ComandoFiscalInterface(ComandoInterface.ComandoInterface):
             @param amount       Importe (sin iva en FC A, sino con IVA)
             @param iva          Porcentaje de Iva
             @param negative True->Descuento, False->Recargo"""
-        raise NotImplementedError
+        pass
 
     def getLastNumber(self, letter):
         """Obtiene el último número de FC"""
-        raise NotImplementedError
+        pass
 
     def getLastCreditNoteNumber(self, letter):
         """Obtiene el último número de FC"""
-        raise NotImplementedError
+        pass
 
     def getLastRemitNumber(self):
         """Obtiene el último número de Remtio"""
-        raise NotImplementedError
+        pass
 
     def cancelAnyDocument(self):
         """Cancela cualquier documento abierto, sea del tipo que sea.
            No requiere que previamente se haya abierto el documento por este objeto.
            Se usa para destrabar la impresora."""
-        raise NotImplementedError
+        pass
 
     def dailyClose(self, type):
         """Cierre Z (diario) o X (parcial)
             @param type     Z (diario), X (parcial)
         """
-        raise NotImplementedError
+        pass
 
     def getWarnings(self):
         return []
 
     def openDrawer(self):
         """Abrir cajón del dinero - No es mandatory implementarlo"""
-        pass
+        print("vino comando aca")
+    	jdata = {
+			"AbrirDocumento":
+			{
+			"CodigoComprobante" : "TiqueFacturaB"
+			}
+		}
+    
+    	self.conector.driver.sendCommand( jdata )

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -76,6 +76,9 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 
 		self.conector.sendCommand( jdata )
 
+	def setTrailer(self, trailer=None):
+		"""Establecer pie"""
+		pass
 
 	def _sendCommand(self, commandNumber, parameters, skipStatusErrors=False):
 		pass
@@ -226,7 +229,7 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 			@param  ivaType     Tipo de IVA
 		"""
 		if name and doc:
-			_setCustomerData(name, address, doc, docType, ivaType)
+			self._setCustomerData(name, address, doc, docType, ivaType)
 
 		return self.__openTicket( "F"+type )
 		
@@ -243,7 +246,7 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 			@param  reference
 		"""
 		if name and doc:
-			_setCustomerData(name, address, doc, docType, ivaType)
+			self._setCustomerData(name, address, doc, docType, ivaType)
 
 		self.__cargarNumReferencia(reference)
 		return self.__openTicket( "NC"+type )
@@ -279,7 +282,7 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 			@param  reference
 		"""
 		if name and doc:
-			_setCustomerData(name, address, doc, docType, ivaType)
+			self._setCustomerData(name, address, doc, docType, ivaType)
 
 		return self.__openTicket( "ND"+type )
 

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -84,7 +84,7 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 	def printFiscalText(self, text):
 		jdata = {"ImprimirTextoFiscal":{
 			"Atributos" : [ "Centrado" ],
-			"Texto" : "Producto en oferta: Sólo por hoy !",
+			"Texto" : text,
 			"ModoDisplay" : "DisplayNo"
 		}}
 

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -55,6 +55,11 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 	}
 
 
+	def getStatus(self, *args):
+		jdata = {"ConsultarEstado":{"CodigoComprobante" : "81"}}
+
+		self.conector.sendCommand( jdata )
+
 
 	def _sendCommand(self, commandNumber, parameters, skipStatusErrors=False):
 		pass

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -200,7 +200,7 @@ class Hasar2GenComandos(ComandoFiscalInterface):
 
 	
 	def __openTicket(self, tipoComprobante):
-		ctype = self.comprobanteTypes.get( comprobanteType )
+		ctype = self.comprobanteTypes.get( tipoComprobante )
 		jdata = {"AbrirDocumento":{
 			"CodigoComprobante" : ctype
 			}

--- a/Comandos/Hasar2GenComandos.py
+++ b/Comandos/Hasar2GenComandos.py
@@ -1,15 +1,21 @@
-# -*- coding: utf-8 -*-
+# -*- coding: iso-8859-1 -*-
+import string
+import types
 import logging
+import unicodedata
+from Comandos.ComandoFiscalInterface import ComandoFiscalInterface
+from Drivers.FiscalPrinterDriver import PrinterException
+from ComandoInterface import formatText
 
 NUMBER = 999990
 
 
-class Hasar2GenComandos:
+class Hasar2GenComandos(ComandoFiscalInterface):
     # el traductor puede ser: TraductorFiscal o TraductorReceipt
     # path al modulo de traductor que este comando necesita
     traductorModule = "Traductores.TraductorFiscal"
 
-    DEFAULT_DRIVER = "ReceiptDirectJet"
+    DEFAULT_DRIVER = "Json"
 
     
     AVAILABLE_MODELS = ["PT-1000F","PT-250F", "P-HAS-5100-FAR"]
@@ -52,8 +58,6 @@ class Hasar2GenComandos:
 
     def printTicket(self, **kargs): 
     	pass
-
-    
 
 
 	def _sendCommand(self, commandNumber, parameters, skipStatusErrors=False):
@@ -235,4 +239,4 @@ class Hasar2GenComandos:
 			}
 		}
     
-    	self.conector.driver.sendCommand( jdata )
+    	self.conector.sendCommand( jdata, 1,1 )

--- a/Drivers/FileDriver.py
+++ b/Drivers/FileDriver.py
@@ -9,10 +9,23 @@ class FileDriver(DriverInterface):
         bufsize = 1  # line buffer
         self.file = open(path, "a", bufsize)
 
-    def sendCommand(self, command, parameters, skipStatusErrors=False):
+    def sendCommand(self, command=0, parameters=None, skipStatusErrors=False):
         import random
-        self.file.write("Command: %d, Parameters: %s\n" % (command, parameters))
-        print("*** OUTPUT Command: %d, Parameters: %s\n" % (command, parameters))
+
+        if isinstance(command,dict):
+            dt={'d': 2, 'f': 2, 'g': 2, 'q': 5, 'w': 3}
+            st=""
+            for key,val in dt.iteritems():
+                st = st + key + str(val)
+            command = st
+
+        if command:
+            self.file.write("Command: %s\n" % command)
+            print("*** OUTPUT Command: %s\n" % command)
+        if parameters:
+            self.file.write("Parameters: %s\n" % command)
+            print("*** OUTPUT Parameters: %s\n" % parameters)
+
         number = random.randint(2, 12432)
         return [str(number)] * 10
 

--- a/Drivers/JsonDriver.py
+++ b/Drivers/JsonDriver.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+
+from DriverInterface import DriverInterface
+import logging
+
+import requests
+import simplejson as json
+
+
+class JsonDriver(DriverInterface):
+
+__name__ = "JsonDriver"
+
+
+    fiscalStatusErrors = []
+
+    printerStatusErrors = []
+
+
+    def __init__(self, host, user, password, port=9999):
+    	logging.getLogger().info("conexion con JSON Driver en host: %s puerto: %s" % (host, port))
+        self.host = host
+        self.user = user
+        self.password = password
+        self.port = port
+
+    def start(self):
+        """Inicia recurso de conexion con impresora"""
+        raise NotImplementedError
+
+    def close(self):
+        """Cierra recurso de conexion con impresora"""
+        raise NotImplementedError
+
+    def sendCommand(self, jsonData):
+        """Envia comando a impresora"""
+
+		url = "http://%s:%s/fiscal.json" % (self.host, self.port)
+		headers = {'Content-type': 'application/json'}
+
+		if self.user and self.password:
+			r = requests.post(url, data=json.dumps(data), headers=headers, auth=(self.user, self.password))
+		else:
+			r = requests.post(url, data=json.dumps(jsonData), headers=headers)
+		print(r)
+        return r
+
+   

--- a/Drivers/JsonDriver.py
+++ b/Drivers/JsonDriver.py
@@ -10,40 +10,41 @@ import simplejson as json
 
 class JsonDriver(DriverInterface):
 
-__name__ = "JsonDriver"
+	__name__ = "JsonDriver"
 
 
-    fiscalStatusErrors = []
+	fiscalStatusErrors = []
 
-    printerStatusErrors = []
+	printerStatusErrors = []
 
 
-    def __init__(self, host, user, password, port=9999):
-    	logging.getLogger().info("conexion con JSON Driver en host: %s puerto: %s" % (host, port))
-        self.host = host
-        self.user = user
-        self.password = password
-        self.port = port
+	def __init__(self, host, user = None, password = None, port=9999):
+		logging.getLogger().info("conexion con JSON Driver en host: %s puerto: %s" % (host, port))
+		self.host = host
+		self.user = user
+		self.password = password
+		self.port = port
 
-    def start(self):
-        """Inicia recurso de conexion con impresora"""
-        raise NotImplementedError
+	def start(self):
+		"""Inicia recurso de conexion con impresora"""
+		raise NotImplementedError
 
-    def close(self):
-        """Cierra recurso de conexion con impresora"""
-        raise NotImplementedError
+	def close(self):
+		"""Cierra recurso de conexion con impresora"""
+		raise NotImplementedError
 
-    def sendCommand(self, jsonData):
-        """Envia comando a impresora"""
-
+	def sendCommand(self, jsonData, parameters, skipStatusErrors):
+		"""Envia comando a impresora"""
+		print("asjoasjoajs oajso jaosjajsoj aosj oasoaosjoajsojosa")
 		url = "http://%s:%s/fiscal.json" % (self.host, self.port)
 		headers = {'Content-type': 'application/json'}
 
 		if self.user and self.password:
-			r = requests.post(url, data=json.dumps(data), headers=headers, auth=(self.user, self.password))
+			r = requests.post(url, data=json.dumps(jsonData), headers=headers, auth=(self.user, self.password))
 		else:
 			r = requests.post(url, data=json.dumps(jsonData), headers=headers)
 		print(r)
-        return r
+		return r
+		
 
    

--- a/Drivers/JsonDriver.py
+++ b/Drivers/JsonDriver.py
@@ -51,6 +51,8 @@ class JsonDriver(DriverInterface):
 				r = requests.post(url, data=json.dumps(jsonData), headers=headers)
 			print("INICIANDO::::")
 			print(r)
+			print(r.json())
+			print(r.content)
 			print("salio la respuesta")
 			
 			return r

--- a/Drivers/JsonDriver.py
+++ b/Drivers/JsonDriver.py
@@ -3,9 +3,11 @@
 
 from DriverInterface import DriverInterface
 import logging
+from FiscalPrinterDriver import PrinterException
+
 
 import requests
-import simplejson as json
+import json
 
 
 class JsonDriver(DriverInterface):
@@ -18,7 +20,7 @@ class JsonDriver(DriverInterface):
 	printerStatusErrors = []
 
 
-	def __init__(self, host, user = None, password = None, port=9999):
+	def __init__(self, host, user = None, password = None, port=80):
 		logging.getLogger().info("conexion con JSON Driver en host: %s puerto: %s" % (host, port))
 		self.host = host
 		self.user = user
@@ -27,24 +29,39 @@ class JsonDriver(DriverInterface):
 
 	def start(self):
 		"""Inicia recurso de conexion con impresora"""
-		raise NotImplementedError
+		pass
 
 	def close(self):
 		"""Cierra recurso de conexion con impresora"""
-		raise NotImplementedError
+		pass
 
-	def sendCommand(self, jsonData, parameters, skipStatusErrors):
+	def sendCommand(self, jsonData, parameters = None, skipStatusErrors = None):
 		"""Envia comando a impresora"""
-		print("asjoasjoajs oajso jaosjajsoj aosj oasoaosjoajsojosa")
 		url = "http://%s:%s/fiscal.json" % (self.host, self.port)
+
+		logging.getLogger().info("conectando a la URL %s"%url)
+		print(jsonData)
 		headers = {'Content-type': 'application/json'}
 
-		if self.user and self.password:
-			r = requests.post(url, data=json.dumps(jsonData), headers=headers, auth=(self.user, self.password))
-		else:
-			r = requests.post(url, data=json.dumps(jsonData), headers=headers)
-		print(r)
-		return r
+
+		try: 
+			if self.password:
+				r = requests.post(url, json=json.dumps(jsonData), headers=headers, auth=(self.user, self.password))
+			else:
+				r = requests.post(url, json=json.dumps(jsonData), headers=headers)
+			print("INICIANDO::::")
+			print(r)
+			print("salio la respuesta")
+			
+			return r
+			
+		except requests.exceptions.Timeout:			
+		    # Maybe set up for a retry, or continue in a retry loop
+		    logging.getLogger().error("titeout de conexion con la fiscal")
+		except requests.exceptions.RequestException as e:
+		    # catastrophic error. bail.
+		    logging.getLogger().error(str(e))
+		
 		
 
    

--- a/Drivers/JsonDriver.py
+++ b/Drivers/JsonDriver.py
@@ -46,9 +46,9 @@ class JsonDriver(DriverInterface):
 
 		try: 
 			if self.password:
-				r = requests.post(url, json=json.dumps(jsonData), headers=headers, auth=(self.user, self.password))
+				r = requests.post(url, data=json.dumps(jsonData), headers=headers, auth=(self.user, self.password))
 			else:
-				r = requests.post(url, json=json.dumps(jsonData), headers=headers)
+				r = requests.post(url, data=json.dumps(jsonData), headers=headers)
 			print("INICIANDO::::")
 			print(r)
 			print("salio la respuesta")

--- a/Drivers/TxtDriver.py
+++ b/Drivers/TxtDriver.py
@@ -9,16 +9,26 @@ class TxtDriver(DriverInterface):
         bufsize = 1  # line buffer
         self.file = open(self.filename, "w", bufsize)
 
-    def sendCommand(self, command, fields, skipStatusErrors=False):
+    def sendCommand(self, command=0, fields=None, skipStatusErrors=False):
         import random
-        message = chr(0x02) + chr(98) + chr(command)
-        if fields:
-            message += chr(0x1c)
-        message += chr(0x1c).join(fields)
-        message += chr(0x03)
-        checkSum = sum([ord(x) for x in message])
-        checkSumHexa = ("0000" + hex(checkSum)[2:])[-4:].upper()
-        message += checkSumHexa
+
+        if isinstance(command,dict):
+            st=""
+            for key,val in command.iteritems():
+                st = st + key + str(val)
+            command = st
+            self.file.write(command + "\n")
+            message = command
+
+        else:
+            message = chr(0x02) + chr(98) + chr(command)
+            if fields:
+                message += chr(0x1c)
+            message += chr(0x1c).join(fields)
+            message += chr(0x03)
+            checkSum = sum([ord(x) for x in message])
+            checkSumHexa = ("0000" + hex(checkSum)[2:])[-4:].upper()
+            message += checkSumHexa
         print message
 
         self.file.write(message + "\n")

--- a/Drivers/TxtDriver.py
+++ b/Drivers/TxtDriver.py
@@ -29,9 +29,8 @@ class TxtDriver(DriverInterface):
             checkSum = sum([ord(x) for x in message])
             checkSumHexa = ("0000" + hex(checkSum)[2:])[-4:].upper()
             message += checkSumHexa
-        print message
+            self.file.write(message + "\n")
 
-        self.file.write(message + "\n")
 
         number = random.randint(2, 12432)
         return [str(number)] * 10

--- a/FiscalberryApp.py
+++ b/FiscalberryApp.py
@@ -214,7 +214,9 @@ class FiscalberryApp:
             logger.info("  - %s" % printer)
             modelo = None
             marca = self.configberry.config.get(printer, "marca")
-            driver = self.configberry.config.get(printer, "driver")
+            driver = "default"
+            if self.configberry.config.has_option(printer, "driver"):
+                driver = self.configberry.config.get(printer, "driver")
             if self.configberry.config.has_option(printer, "modelo"):
                 modelo = self.configberry.config.get(printer, "modelo")
             logger.info("      marca: %s, driver: %s" % (marca, driver))

--- a/FiscalberryDiscover.py
+++ b/FiscalberryDiscover.py
@@ -3,11 +3,12 @@
 import requests
 import uuid
 import json
+import logging
+
 
 
 def send(configberry):
     if not configberry.config.has_option('SERVIDOR', "uuid"):
-        print uuid.getnode()
         uuidvalue = str(uuid.uuid1(uuid.getnode(), 0))[24:]
         configberry.writeSectionWithKwargs('SERVIDOR', {'uuid': uuidvalue})
 
@@ -17,14 +18,16 @@ def send(configberry):
         "raw_data": json.dumps(configberry.getJSON())
     }
 
-    print senddata
 
     discoverUrl = configberry.config.get('SERVIDOR', "discover_url")
 
-    try:
-        print requests.post(discoverUrl, data=senddata)
-    except Exception, e:
-        print("Mensaje de exception del discover: ", e)
+    ret = None
+    if discoverUrl:
+        try:
+            ret = requests.post(discoverUrl, data=senddata)
+        except Exception, e:
+            logging.getLogger().info("Mensaje de exception del discover: %s", e)
 
+    return ret
     # resp.raise_for_status()
 

--- a/Traductores/TraductorFiscal.py
+++ b/Traductores/TraductorFiscal.py
@@ -32,7 +32,7 @@ class TraductorFiscal(TraductorInterface):
         letra_cbte = tipo_cbte[-1] if len(tipo_cbte) > 1 else None
         return self.comando.getLastNumber(letra_cbte)
 
-    def cancelDocument(self):
+    def cancelDocument(self, *args):
         "Cancelar comprobante en curso"
         return self.comando.cancelDocument()
 
@@ -136,6 +136,6 @@ class TraductorFiscal(TraductorInterface):
         self.factura["pagos"].append(dict(ds=ds, importe=importe))
         return self.comando.addPayment(ds, float(importe))
 
-    def _cerrarComprobante(self):
+    def _cerrarComprobante(self, *args):
         "Envia el comando para cerrar un comprobante Fiscal"
         return self.comando.closeDocument()

--- a/Traductores/TraductorFiscal.py
+++ b/Traductores/TraductorFiscal.py
@@ -12,6 +12,11 @@ class TraductorFiscal(TraductorInterface):
         ret = self.comando.dailyClose(type)
         return ret
 
+    def getStatus(self, *args):
+        "getStatus"
+        ret = self.comando.getStatus(list(args))
+        return ret
+
     def setHeader(self, *args):
         "SetHeader"
         ret = self.comando.setHeader(list(args))

--- a/Traductores/TraductorInterface.py
+++ b/Traductores/TraductorInterface.py
@@ -8,7 +8,6 @@ class TraductorInterface:
     def run(self, jsonTicket):
         actions = jsonTicket.keys()
         rta = []
-
         for action in actions:
             fnAction = getattr(self, action)
 
@@ -21,6 +20,10 @@ class TraductorInterface:
                 rta.append({"action": action, "rta": res})
 
             else:
+                print("asjkhashahsaishauhsiahiushaihs")
+                print(fnAction)
+                print(jsonTicket[action])
+                print("asjkhashahsaishauhsiahiushaihs")
                 res = fnAction(jsonTicket[action])
                 rta.append({"action": action, "rta": res})
 

--- a/Traductores/TraductorInterface.py
+++ b/Traductores/TraductorInterface.py
@@ -20,10 +20,6 @@ class TraductorInterface:
                 rta.append({"action": action, "rta": res})
 
             else:
-                print("asjkhashahsaishauhsiahiushaihs")
-                print(fnAction)
-                print(jsonTicket[action])
-                print("asjkhashahsaishauhsiahiushaihs")
                 res = fnAction(jsonTicket[action])
                 rta.append({"action": action, "rta": res})
 

--- a/Traductores/TraductoresHandler.py
+++ b/Traductores/TraductoresHandler.py
@@ -114,6 +114,7 @@ class TraductoresHandler:
         device_list = [
             '00:0E:C3',  # Logic Controls BEMATECH
             '00:07:25',  # Bematech
+            'D8:D8:D8',  # Hasar 2Gen
         ]
 
         avaliablePrinters = []  # lo retornado

--- a/Traductores/TraductoresHandler.py
+++ b/Traductores/TraductoresHandler.py
@@ -176,7 +176,7 @@ class TraductoresHandler:
         libraryName = "Comandos." + marca + "Comandos"
         comandoModule = importlib.import_module(libraryName)
         comandoClass = getattr(comandoModule, marca + "Comandos")
-
+        
         comando = comandoClass(**dictSectionConf)
         return comando.traductor
 

--- a/Traductores/TraductoresHandler.py
+++ b/Traductores/TraductoresHandler.py
@@ -176,7 +176,11 @@ class TraductoresHandler:
 
     def __init_printer_traductor(self, printerName):
 
-        dictSectionConf = self.config.get_config_for_printer(printerName)
+        try:
+            dictSectionConf = self.config.get_config_for_printer(printerName)
+        except KeyError as e:
+            raise TraductorException("En el archivo de configuracion no existe la impresora: '%s'" % printerName)
+
         marca = dictSectionConf.get("marca")
         del dictSectionConf['marca']
         # instanciar los comandos dinamicamente

--- a/config.ini.install
+++ b/config.ini.install
@@ -1,5 +1,7 @@
 [SERVIDOR]
 puerto = 12000
+discover_url = 
+
 
 [IMPRESORA_FISCAL]
 marca = Hasar

--- a/datajson.json
+++ b/datajson.json
@@ -1,0 +1,1 @@
+{"ConsultarEstado":{"CodigoComprobante" : "81"}}

--- a/js_browser_client/example_ws_client.html
+++ b/js_browser_client/example_ws_client.html
@@ -72,6 +72,7 @@
 
     <input type="button" id="msg-status" value="Mensaje Status (get Config values)"/>
     <input type="button" id="msg-lst-number" value="Last Ticket Number"/>
+    <input type="button" id="msg-cancel" value="Cancelar Comprobante en curso"/>
     <input type="button" id="msg-daily" value="Cierre X"/>
     <input type="button" id="msg-ticket" value="Ticket"/>
     <input type="button" id="msg-nc" value="Nota de Credito Factura A"/>
@@ -305,6 +306,10 @@
 
     $("#msg-daily").on('click', function () {
         ponerJSONenTextarea('{"dailyClose": "X"}');
+    });
+
+    $("#msg-cancel").on('click', function () {
+        ponerJSONenTextarea('{"cancelDocument": ""}');
     });
 
     $("#msg-get-printers").on('click', function () {

--- a/js_browser_client/example_ws_client.html
+++ b/js_browser_client/example_ws_client.html
@@ -71,6 +71,7 @@
             <select name="marca_impresora">
                 <option value="EscP">EscP</option>
                 <option value="Hasar">Hasar</option>
+                <option value="Hasar2Gen">Hasar2Gen</option>
                 <option value="Epson">Epson</option>
             </select>
 
@@ -88,6 +89,7 @@
                 <option value="ReceiptDirectJet">ReceiptDirectJet</option>
                 <option value="Epson">Epson</option>
                 <option value="Hasar">Hasar</option>
+                <option value="Hasar2Gen">Hasar2Gen</option>
                 <option value="File">File</option>
             </select>
 

--- a/probandocurl.sh
+++ b/probandocurl.sh
@@ -1,0 +1,2 @@
+#bash
+curl --noproxy 192.168.1.38 http://192.168.1.38/fiscal.json -H "Content-Type: application/json" --data-binary datajson.json > resp.json


### PR DESCRIPTION
Se agregó el soporte a impresoras Hasar de 2da generacion

Comandos testeados que funcionan hasta el momento:

- print ticket (comprobantes A, B y C)
- Cierre Zeta
- Cierre X

Pendientes:
Nota de credito, debito, remitos, etc, etc.

Tampoco pude agregar la posibilidad de imprimir tecto libre en el Trailer o pie de pagina.

Pero al menos los comandos basicos funcionan.