### PR TITLE
En fallo de autorización por http request el response debe ir con código de error ( 401 ).

### DIFF
--- a/ApiRest/Auth.py
+++ b/ApiRest/Auth.py
@@ -11,7 +11,7 @@ AUTHORIZATION_METHOD = 'bearer'
 #SECRET_KEY = "my_secret_key"
 INVALID_HEADER_MESSAGE = "invalid header authorization"
 MISSING_AUTHORIZATION_KEY = "Missing authorization"
-AUTHORIZTION_ERROR_CODE = 401
+AUTHORIZATION_ERROR_CODE = 401
 
 jwt_options = {
     'verify_signature': True,
@@ -69,7 +69,7 @@ def return_auth_error(handler, message):
     """
     response= {}
     handler._transforms = []
-    handler.set_status(AUTHORIZTION_ERROR_CODE)
+    handler.set_status(AUTHORIZATION_ERROR_CODE)
     response['err']= message
     handler.write(response)
     handler.finish()
@@ -105,6 +105,7 @@ def jwtauth(handler_class):
 
             else:
                 handler._transforms = []
+                handler.set_status(AUTHORIZATION_ERROR_CODE)
                 handler.write(MISSING_AUTHORIZATION_KEY)
                 handler.finish()
 


### PR DESCRIPTION
Hola!
Estuve probando un poco fiscalberry y todo va muy bien por ahora, gran trabajo, gracias por compartirlo!
Encontré un pequeño detalle que quería hacérselos saber. En el caso de fallo de autorización en /api/auth está devolviendo código 200 ( success ) en vez de 401. Más allá de que no es crítico sería mejor que retorne un código de error para que tenga sentido. De paso arreglé un typo.
Saludos!
Gracias por todo!