### PR TITLE
ISSUE #120: Impuestos internos como núm. Decimal.

### DIFF
--- a/Comandos/Epson2GenComandos.py
+++ b/Comandos/Epson2GenComandos.py
@@ -138,7 +138,7 @@ class Epson2GenComandos(ComandoFiscalInterface):
         return self.conector.driver.EpsonLibInterface.CargarDatosCliente(str(name1), str(name2), str(address1), str(address2), str(address3), docType, str(doc) , ivaType)
 
     def addItem(self, description, quantity, price, iva, itemNegative=False, discount=0, discountDescription='',
-                discountNegative=False, id_ii=0, ii_valor="", id_codigo=1, codigo="1",
+                discountNegative=False, id_ii=0, ii_valor=0, id_codigo=1, codigo="1",
                 codigo_unidad_matrix="1",codigo_unidad_medida=0):
         """Agrega un item a la FC.
                 * param `description`          Descripción del item. Puede ser un string o una lista.
@@ -166,12 +166,16 @@ class Epson2GenComandos(ComandoFiscalInterface):
         qty = str(quantity)
         description = c_char_p(description).value
         precio = str(price)
+        iiValor = ""
+
+        if (ii_valor > 0):
+            str(ii_valor)
 
         logging.info("Item:  Mod: %s - Desc: %s Cant: %s - Precio: %s - Iva: %s - IIid: %d - IIvalor: %s" %
-              (id_item, description, qty, precio, ivaid, id_ii, ii_valor))
+              (id_item, description, qty, precio, ivaid, id_ii, iiValor))
 
         return self.conector.driver.EpsonLibInterface.ImprimirItem(id_item, description, qty, precio, ivaid, id_ii,
-                ii_valor,id_codigo, codigo, codigo_unidad_matrix, codigo_unidad_medida)
+                iiValor,id_codigo, codigo, codigo_unidad_matrix, codigo_unidad_medida)
 
     def openTicket(self, comprobanteType="T"):
         """Abre ticket

--- a/Comandos/Epson2GenComandos.py
+++ b/Comandos/Epson2GenComandos.py
@@ -209,7 +209,7 @@ class Epson2GenComandos(ComandoFiscalInterface):
         return ret
 
     def imprimirTextoLibre(self, linea=""):
-        ret = self.conector.driver.EpsonLibInterface.ImprimirTextoLibre(linea)
+        ret = self.conector.driver.EpsonLibInterface.ImprimirTextoLibre(str(linea))
         return ret
 
     """ @fchiappano Abrir un tiquet no fiscal """

--- a/Traductores/TraductorFiscal.py
+++ b/Traductores/TraductorFiscal.py
@@ -155,7 +155,7 @@ class TraductorFiscal(TraductorInterface):
         return ret
 
     def _imprimirItem(self, ds, qty, importe, alic_iva=21., itemNegative=False, discount=0, discountDescription='',
-                      discountNegative=False, **kwargs):
+                      discountNegative=False, id_ii = 0, ii_valor = 0, **kwargs):
         "Envia un item (descripcion, cantidad, etc.) a una factura"
 
         if importe < 0:
@@ -172,7 +172,7 @@ class TraductorFiscal(TraductorInterface):
             discountDescription = ds
 
         return self.comando.addItem(ds, float(qty), float(importe), float(alic_iva),
-                                    itemNegative, float(discount), discountDescription, discountNegative, **kwargs)
+                                    itemNegative, float(discount), discountDescription, discountNegative, id_ii, float(ii_valor), **kwargs)
 
     def _imprimirPago(self, ds, importe):
         "Imprime una linea con la forma de pago y monto"

--- a/Traductores/TraductorFiscal.py
+++ b/Traductores/TraductorFiscal.py
@@ -67,6 +67,21 @@ class TraductorFiscal(TraductorInterface):
         self.comando.cancelAnyDocument()
         self.comando.close()
 
+    def printDNFH(self, tipo_cbte="G", lineas=[]):
+        self.comando.start()
+        try:
+            self.comando.openDNFH(tipo_cbte)
+
+            for linea in lineas:
+                self.comando.imprimirTextoLibre(linea)
+
+            rta = self.comando.closeDNFH()
+            self.comando.close()
+            return rta
+        except Exception as e:
+          self.cancelDocument()
+          raise
+
     def printTicket(self, encabezado=None, items=[], pagos=[], percepciones=[], addAdditional=None, setHeader=None, setTrailer=None):
         if setHeader:
             self.setHeader(*setHeader)
@@ -151,6 +166,9 @@ class TraductorFiscal(TraductorInterface):
             ret = printer.openBillCreditTicket(letra_cbte, nombre_cliente,
                                                domicilio_cliente, nro_doc, doc_fiscal,
                                                pos_fiscal, referencia)
+        elif tipo_cbte.startswith("NFP"):
+            ret = printer.openBillTicketNoFiscal(letra_cbte, nombre_cliente, domicilio_cliente,
+                                         nro_doc, doc_fiscal, pos_fiscal, referencia)
 
         return ret
 
@@ -172,7 +190,7 @@ class TraductorFiscal(TraductorInterface):
             discountDescription = ds
 
         return self.comando.addItem(ds, float(qty), float(importe), float(alic_iva),
-                                    itemNegative, float(discount), discountDescription, discountNegative, id_ii, float(ii_valor), **kwargs)
+                                    itemNegative, float(discount), discountDescription, discountNegative, id_ii, ii_valor, **kwargs)
 
     def _imprimirPago(self, ds, importe):
         "Imprime una linea con la forma de pago y monto"


### PR DESCRIPTION
Se modificaron los parametros en los metodos de impresión de items (en
traductor y comando), para que el importe de impuesto interno
(ii_importe) pueda ser enviado como un número decimal dentro del json y
de esta manera, se eviten errores de formato al enviar el dato al
controlador fiscal.