### PR TITLE
fix(comanda): reducir espacio en blanco en la impresión de comandas

### DIFF
--- a/src/fiscalberry/common/EscPComandos.py
+++ b/src/fiscalberry/common/EscPComandos.py
@@ -904,7 +904,7 @@ class EscPComandos():
         if setHeader:
             for headerLine in setHeader:
                 printer.textln(headerLine)
-            printer.text("\n\n")
+            printer.text("\n")
 
         if "id" in comanda:
             printer.text(f"Comanda #{comanda['id']}\n")
@@ -913,47 +913,45 @@ class EscPComandos():
             fecha = datetime.datetime.strptime(comanda['created'], '%Y-%m-%d %H:%M:%S').strftime('%H:%M',)
         else:
             fecha = datetime.datetime.strftime(datetime.datetime.now(), '%H:%M')
-            
-        printer.text(fecha + "\n\n")
+
+        printer.text(fecha + "\n")
 
         def print_plato(plato):
             "Imprimir platos"
             printer.set(font='a', bold=False, height=2, width=2, align='left', double_height=True, double_width=False)
 
-            printer.text(f"{plato['cant']}) {plato['nombre']}")
+            # El nombre cierra siempre su propia línea; antes las líneas en blanco entre
+            # sabores/OBS/ítems desperdiciaban mucho papel. Se mantienen las fuentes, se
+            # sacan los \n en blanco. Ver issue #47.
+            printer.text(f"{plato['cant']}) {plato['nombre']}\n")
 
             if 'sabores' in plato:
-                printer.text("\n")
                 for sabor in plato['sabores']:
                     printer.text(f"   - {sabor}\n")
-                printer.text("\n")
 
             if 'observacion' in plato:
-                printer.text("\n")
                 printer.set(font='b', bold=False, height=2, width=2, align='left', double_height=False, double_width=False)
                 printer.text(f"   OBS: {plato['observacion']}\n")
-                
-            printer.text("\n")
 
         if 'observacion' in comanda:
             printer.set(font='a', bold=True, height=2, width=2, align='center', double_height=True, double_width=True)
             printer.text(u"OBSERVACIÓN\n")
             printer.text(comanda['observacion'])
-            printer.text("\n\n")
+            printer.text("\n")
 
         if 'entradas' in comanda:
             printer.set(font='a', bold=True, height=2, width=2, align='center', double_height=True, double_width=True)
-            printer.text(u"** ** ENTRADA ** **\n\n")
+            printer.text(u"** ** ENTRADA ** **\n")
             for entrada in comanda['entradas']:
                 print_plato(entrada)
-            printer.text("\n\n")
+            printer.text("\n")
 
         if 'platos' in comanda:
             printer.set(font='a', bold=True, height=2, width=2, align='center', double_height=True, double_width=True)
-            printer.text(u"----- PRINCIPAL -----\n\n")
+            printer.text(u"----- PRINCIPAL -----\n")
             for plato in comanda['platos']:
                 print_plato(plato)
-            printer.text("\n\n")
+            printer.text("\n")
 
         printer.set(font='a', bold=True, height=2, width=2, align='left', double_height=True, double_width=True)
         if self.__preFillTrailer:


### PR DESCRIPTION
Reduce el espacio en blanco vertical en la impresión de comandas (`EscPComandos.py`): se sacan líneas en blanco redundantes en `printComanda`/`print_plato` conservando las fuentes/tamaños. Cada ítem sigue cerrando con un único salto de línea.

Fix conservador (solo whitespace), sin cambios de lógica ni de fuentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)